### PR TITLE
Update sample in spree initializer template

### DIFF
--- a/core/lib/generators/spree/install/templates/config/initializers/spree.rb
+++ b/core/lib/generators/spree/install/templates/config/initializers/spree.rb
@@ -47,7 +47,7 @@ Spree.config do |config|
   #   secret_key: ENV['STRIPE_SECRET_KEY'],
   #   publishable_key: ENV['STRIPE_PUBLISHABLE_KEY'],
   #   server: Rails.env.production? ? 'production' : 'test',
-  #   test: !Rails.env.production?
+  #   test_mode: !Rails.env.production?
   # )
 end
 


### PR DESCRIPTION
The correct preference key for Spree::Gateway is "test_mode" not "test". This can be seen in:

core/app/models/spree/gateway.rb

This commit updates the sample in the initializer template to the correct preference key.